### PR TITLE
Nginx - Save files to disk instead of RAM

### DIFF
--- a/src/remy/file_obj.lua
+++ b/src/remy/file_obj.lua
@@ -1,0 +1,37 @@
+-- Remy - File object
+-- By m1cr0man
+-- License: MIT
+
+local File = {
+	name = nil,
+	path = nil,
+	content_type = nil,
+	move_to = nil,
+	handle = nil
+}
+
+-- Efficiency function for saving the temp file
+-- somewhere else instead of reading & writing it
+function File:move_to(path)
+	local success, err = os.rename(self.path, path)
+	if not success then return success, err end
+	self.path = path
+	return true
+end
+
+function File.new(name, content_type)
+	local new_file = {
+		name = name,
+		path = os.tmpname(),
+		content_type = content_type
+	}
+
+	-- We will want a handle to write to
+	-- when we create the file
+	new_file.handle = io.open(new_file.path, "w")
+	setmetatable(new_file, {__index = File})
+
+	return new_file
+end
+
+return File


### PR DESCRIPTION
This is part of [the ongoing issue](https://github.com/sailorproject/sailor/issues/79) to abstract file uploading in Sailor. See my comment on that issue for a long description of why this is needed and what this intends to do. TL;DR mod_lua doesn't actually support large file uploads at all so this will all be a custom implementation (ie a non-emulated feature).

My socket-based request streaming is only used if the content-disposition is `multipart/form-data`. Otherwise it still uses `ngx.req.get_post_args()` and thus shouldn't break anything.

This supports multiple file uploads under the same value key, and does the same thing the standard `ngx.req.get_post_args()` function does - it sets the returned value to an array/table of all the values.

I broke the file object that is returned in the POST data into a separate module so that it can be used when abstracting the other webservers.

When a file upload is detected, the value in the POST table becomes an object/table which looks like this:

``` lua
file = { -- Key will be whatever the form "name" value was
  name = "myfile.txt", -- Original file name
  path = "/tmp/lua_wevC3", -- Path to the temporary file containg the data
  content_type = "text/plain" -- Content-Type from the HTTP request header
  move_to = function(self, path) -- Used to move the temporary file to a new
                                 -- location, instead of read/writing it
}
```

Oh! And one last very important note: `lua_need_request_body` must be turned `off` in your nginx.conf now. [Explanation here](https://github.com/openresty/lua-nginx-module#ngxreqsocket)
