### PR TITLE
set nginx status code

### DIFF
--- a/src/remy/nginx.lua
+++ b/src/remy/nginx.lua
@@ -181,6 +181,9 @@ function M.contentheader(content_type)
 end
 
 function M.finish(code)
+	-- Set status code
+	ngx.status = code
+
 	-- Set the headers
 	if request.content_type and not ngx.header.content_type then
 		ngx.header["Content-Type"] = request.content_type


### PR DESCRIPTION
Set the response status code received from `handler_func` in `remy.run`, otherwise redirection/error codes will not be passed to nginx.
