### PR TITLE
Fix typo in Lwan support for response headers

### DIFF
--- a/src/remy/lwan.lua
+++ b/src/remy/lwan.lua
@@ -88,7 +88,7 @@ function M.contentheader(content_type)
 end
 
 function M.finish(code)
-    r.native_request:set_headers(request.headers_out)
+    request.native_request:set_headers(request.headers_out)
 end
 
 return M


### PR DESCRIPTION
That's the correct branch now. :P
