### PR TITLE
Enhancement add custom http headers to cgilua

### DIFF
--- a/src/remy/cgilua.lua
+++ b/src/remy/cgilua.lua
@@ -96,23 +96,23 @@ end
 -- TODO: better handle the return code
 function M.finish(code)
 	local r = request
-	
+
 	-- Handle page redirect
 	local location = r.headers_out['Location']
-  if location ~= nil and r.status == 302 then
-     if location:match('^https?://') then
-				cgilua.redirect(location)
-     else
-        -- CGILua needs a full URL
-        if r.is_https then
-					location = 'https://'..cgilua.servervariable("HTTP_HOST")..location
-        else
-					location = 'http://'..cgilua.servervariable("HTTP_HOST")..location
-        end
-				cgilua.redirect(location)
-     end
-  end
-	
+	if location ~= nil and r.status == 302 then
+		if location:match('^https?://') then
+			cgilua.redirect(location)
+		else
+	-- CGILua needs a full URL
+			if r.is_https then
+				location = 'https://'..cgilua.servervariable("HTTP_HOST")..location
+			else
+				location = 'http://'..cgilua.servervariable("HTTP_HOST")..location
+			end
+		cgilua.redirect(location)
+		end
+	end
+
 	-- Prints the response text (if any)
 	if r.content_type == "text/html" then
 		cgilua.htmlheader()
@@ -122,8 +122,9 @@ function M.finish(code)
 		local header_subtype = remy.splitstring(r.content_type,header_sep)[2]
 		cgilua.contentheader(header_type,header_subtype)
 	end
+
 	if remy.responsetext ~= nil then
-	   cgilua.print(remy.responsetext)
+		cgilua.print(remy.responsetext)
 	end
 end
 

--- a/src/remy/cgilua.lua
+++ b/src/remy/cgilua.lua
@@ -96,14 +96,14 @@ end
 -- TODO: better handle the return code
 function M.finish(code)
 	local r = request
-
+	
 	-- Handle page redirect
 	local location = r.headers_out['Location']
 	if location ~= nil and r.status == 302 then
 		if location:match('^https?://') then
 			cgilua.redirect(location)
 		else
-	-- CGILua needs a full URL
+			-- CGILua needs a full URL
 			if r.is_https then
 				location = 'https://'..cgilua.servervariable("HTTP_HOST")..location
 			else
@@ -111,6 +111,18 @@ function M.finish(code)
 			end
 		cgilua.redirect(location)
 		end
+	end
+
+	-- add support for custom headers 
+	for header, value in pairs(r.headers_out) do
+		-- skip Location header. 
+		if header == "Location" then
+			goto continue
+		end
+
+		cgilua.header(header, value)
+
+		::continue::
 	end
 
 	-- Prints the response text (if any)


### PR DESCRIPTION
This PR adds support for sending custom headers from cgilua.

Those using remy/sailor to implement custom API servers need the ability to use custom headers to implement CORS and other specs. 

The implementation here will use the `headers_out` table to find new headers to send taking care to skip "Location" since it is handled elsewhere.
